### PR TITLE
modified entry point to fix issue with require

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ll-protocol",
   "version": "1.0.1",
   "description": "Custom TCP protocol",
-  "main": "LLProtocol.js",
+  "main": "src/LLProtocol.js",
   "scripts": {
     "test": "mocha --reporter spec",
     "test-watch": "mocha --reporter spec --watch"


### PR DESCRIPTION
Node could not require the module because the entry point specified in the package.json didn't exist.